### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/minetro/cli-http-extension) |
 | PHP | ![](https://badgen.net/packagist/php/minetro/cli-http-extension) |
-| License | ![](https://badgen.net/github/license/minetro/cli-http-extensionp) |
+| License | ![](https://badgen.net/github/license/contributte/cli-http) |
 
 CLI HTTP Extension for Nette. Provide URL in your CLI mode only, it does not override your `http.request` in other modes.
 
@@ -56,7 +56,7 @@ clihttp:
 
 ## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -65,4 +65,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
This PR fixes formatting issues in the archived README:

- Fixed typo in license badge URL (removed extra 'p' and updated to use correct GitHub repo path)
- Fixed grammar: "was maintain" → "was maintained"
- Fixed grammar: "for being used" → "for using"

The repository was already in archive style but had these minor issues that needed correction.